### PR TITLE
【サーバサイド】商品詳細表示

### DIFF
--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -1,6 +1,5 @@
 .productDtail
   .productShowContent
-    
     -if user_signed_in? && current_user.id == @product.user_id
       .productEditLink
         .productEditLink__btn


### PR DESCRIPTION
#What
1. [こちらの見本](http://furima.tokyo/)と同じような形で、商品出品時に登録した情報が見られるようになってる
2.ログアウト状態でも商品詳細ページを見ることができる
3.出品者にしか商品の情報編集・削除のリンクが踏めないようになっている
4.出品者以外にしか商品購入のリンクが踏めないようになっている

#Why
メンターレビューを受けるため
https://gyazo.com/e52ce4f52e3a9625c0eeed66d714d9fb
https://gyazo.com/5a3ebb419410e431cfc63b395f76766c
https://gyazo.com/2fc29480413f60326fd49cb1eb9e99e8