### PR TITLE
ユーザー新規登録時、バリデーションの設定

### DIFF
--- a/app/assets/stylesheets/_registration.scss
+++ b/app/assets/stylesheets/_registration.scss
@@ -4,133 +4,137 @@
   flex-direction: column;
 }
 
-  .usersNewHeader  {
-    height: 150px;
-    background-color: rgba($color: #ebe7e7be, $alpha: 1.0);
-    img{
-      display: block;
-      margin: 0 auto;
-      padding: 50px;
-      width: 300px;
-    }  
+.usersNewHeader {
+  height: 150px;
+  background-color: rgba($color: #ebe7e7be, $alpha: 1);
+  img {
+    display: block;
+    margin: 0 auto;
+    padding: 50px;
+    width: 300px;
   }
+}
 
-  .layout {
-    display: flex;
+.layout {
+  display: flex;
+  flex: 1;
+  h1 {
+    font-size: 22px;
+    font-weight: bold;
+    text-align: center;
+    padding: 20px;
+    border-bottom: 2px solid #ebe7e7be;
+  }
+  &__center {
     flex: 1;
-    h1 {
-      font-size: 22px;
-      font-weight: bold;
-      text-align: center;
-      padding: 20px;
-      border-bottom: 2px solid #ebe7e7be;
-    }
-    &__center{
-      flex: 1;
-      font-size: 15px;
-      .center__content {
-        width: 360px;
-        height: 750px;
-        margin:0 auto;
-      }
-    }
-    &__left {
-      width: 400px;
-      background-color: rgba($color: #ebe7e7be, $alpha: 1.0);
-    }
-    &__right {
-      width: 400px;
-      background-color: rgba($color: #ebe7e7be, $alpha: 1.0);
+    font-size: 15px;
+    .center__content {
+      width: 360px;
+      height: 750px;
+      margin: 0 auto;
     }
   }
-  .usersNewWrapper{
+  &__left {
+    width: 400px;
+    background-color: rgba($color: #ebe7e7be, $alpha: 1);
+  }
+  &__right {
+    width: 400px;
+    background-color: rgba($color: #ebe7e7be, $alpha: 1);
+  }
+}
+.usersNewWrapper {
+  padding-left: 10px;
+}
+
+.sign__label {
+  width: 340px;
+  padding-top: 20px;
+  &__head {
+    height: 30px;
+    width: 50px;
+    font-weight: bold;
+  }
+  &__required {
+    background-color: rgba($color: #e91212, $alpha: 1);
+    color: rgba($color: white, $alpha: 1);
+    text-align: center;
+    border-radius: 5px;
+    padding: 5px;
+  }
+}
+
+.usersNewform {
+  height: 50px;
+  width: 340px;
+  padding-top: 10px;
+  display: flex;
+  &__defalt {
+    width: 340px;
+    height: 40px;
+    border: 2px solid #ebe7e7be;
+    border-radius: 5px;
     padding-left: 10px;
   }
-
-  .sign__label {
-    width: 340px;
-    padding-top: 20px;
-    &__head {
-      height: 30px;
-      width: 50px;
-      font-weight: bold;
-    }
-    &__required {
-      background-color: rgba($color: #e91212, $alpha: 1.0);
-      color: rgba($color: white, $alpha: 1.0);
-      text-align: center;
-      border-radius: 5px;
-      padding: 5px;
-    }
+  &__half {
+    width: 170px;
+    height: 40px;
+    border: 2px solid #ebe7e7be;
+    border-radius: 5px;
+    padding-left: 10px;
   }
+}
 
+.select__form {
+  height: 40px;
+  width: 340px;
+  padding-top: 10px;
+  display: flex;
+  select {
+    width: 70px;
+    height: 40px;
+    border: 2px solid #ebe7e7be;
+    border-radius: 5px;
+  }
+}
 
-  .usersNewform {
-    height: 50px;
-    width: 340px;
-    padding-top: 10px;
-    display: flex;
-    &__defalt {
+.usersNewLogin {
+  height: 180px;
+  width: 345px;
+  padding-top: 40px;
+  &__frame {
+    height: 40px;
+    &__btn {
+      display: block;
       width: 340px;
       height: 40px;
-      border: 2px solid #ebe7e7be;
+      border: 2px solid #3ccace;
+      background-color: #3ccace;
       border-radius: 5px;
-      padding-left: 10px;
-    }
-    &__half {
-      width: 170px;
-      height: 40px;
-      border: 2px solid #ebe7e7be;
-      border-radius: 5px;
-      padding-left: 10px;
+      line-height: 35px;
+      text-align: center;
+      font-size: 20px;
+      color: white;
+      text-decoration: none;
     }
   }
+}
 
-
-  .select__form {
-    height: 40px;
-    width: 340px;
-    padding-top: 10px;
-    display: flex;
-      select {
-      width: 70px;
-      height: 40px;
-      border: 2px solid #ebe7e7be;
-      border-radius: 5px;
-    }
+.usersNewfooter {
+  height: 150px;
+  background-color: rgba($color: #ebe7e7be, $alpha: 1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  img {
+    margin: ０ auto;
+    padding: 0px;
+    width: 200px;
   }
+}
 
-  .usersNewLogin {
-    height: 180px;
-    width: 345px;
-    padding-top: 40px;
-    &__frame {
-      height: 40px;
-      &__btn {
-        display: block;
-        width: 340px;
-        height: 40px;
-        border: 2px solid #3CCACE;
-        background-color: #3CCACE;;
-        border-radius: 5px;
-        line-height: 35px;
-        text-align: center;
-        font-size: 20px;
-        color: white;
-        text-decoration: none;
-      }
-    }
-  }
-
-  .usersNewfooter {
-    height: 150px;
-    background-color: rgba($color: #ebe7e7be, $alpha: 1.0);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    img{
-      margin: ０ auto;
-      padding: 0px;
-      width: 200px;
-    }
-  }
+#error_explanation {
+  margin: 10px 0px 30px;
+  color: red;
+  text-align: center;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,3 +9,4 @@
 @import "sessions";
 @import "purchase";
 @import "addresses";
+@import "sighIn_up_logout-flash";

--- a/app/assets/stylesheets/sighIn_up_logout-flash.scss
+++ b/app/assets/stylesheets/sighIn_up_logout-flash.scss
@@ -1,0 +1,13 @@
+.sighIn_up_logout-flash {
+  .notice {
+    background-color: #3ccace;
+    color: white;
+    text-align: center;
+  }
+
+  .alert {
+    background-color: lightsalmon;
+    color: white;
+    text-align: center;
+  }
+}

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,4 +1,6 @@
 class ProductsController < ApplicationController
+  before_action :move_to_root, except: [:index, :show]
+
   def index
     @categoryProducts = Product.includes(:images).limit(3).order("id DESC")
     @categoryBrand = Product.includes(:images).limit(3).order("RAND()")
@@ -33,6 +35,10 @@ class ProductsController < ApplicationController
   
   def brand_params
     params[:product].require(:brand).permit(:name)
+  end
+
+  def move_to_root
+    redirect_to new_user_session_path unless user_signed_in?
   end
 end
 

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/plataformatec/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,4 +3,7 @@ class UsersController < ApplicationController
     @user = User.find(current_user.id)
   end
 
+  def index
+    redirect_to new_user_registration_path
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,23 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  with_options presence: true do
+    validates :nickname
+    validates :birthday
+    validates :email,    uniqueness: {case_sensitive: false},format: {with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i}
+    validates :password, length: {minimum: 7}
+    
+    with_options format: {with: /\A(?:\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々])+\z/} do
+      validates :family_name
+      validates :first_name
+    end
+    
+    with_options format: {with: /\A[\p{katakana} ー－&&[^ -~｡-ﾟ]]+\z/} do
+      validates :family_name_kana
+      validates :first_name_kana
+    end
+  end
+
   # has_many :comments
   # has_many :credits
   # has_many :dealings

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,13 +1,14 @@
 .usersNew
   .usersNewHeader 
-    = link_to '' do 
+    = link_to root_path do 
       = image_tag asset_path("material/logo/logo.png")
   .layout
     .layout__left
     .layout__center 
+      = render "devise/shared/error_messages", resource: resource
       %h1 会員登録
       .center__content
-        = form_with scope: resource, as: resource_name, url: registration_path(resource_name) do |f|
+        = form_with scope: resource, as: resource_name, url: registration_path(resource_name),local: true do |f|
           .usersNewWrapper
             .sign__label
               %label.sign__label__head
@@ -25,7 +26,7 @@
               = f.email_field :email, autofocus: true, placeholder: "Eメール", class: "usersNewform__defalt"
             .sign__label
               %label.sign__label__head
-                パスワード
+                パスワード(7文字以上)
               %span.sign__label__required
                 必須
             .usersNewform
@@ -59,11 +60,11 @@
               %span.sign__label__required
                 必須
             .select__form
-              = f.date_select :birthday, use_month_numbers: true, start_year: Time.now.year, end_year: (Time.now.year - 50), default: Date.new(Time.now.year,Time.now.month,Time.now.day)
+              = f.date_select :birthday, use_month_numbers: true, start_year: Time.now.year, end_year: (Time.now.year - 50),include_blank: true
             .usersNewLogin
               .usersNewLogin__frame
                 = f.submit "登録する", class: "usersNewLogin__frame__btn"
     .layout__right
   .usersNewfooter
-    = link_to '#' do 
+    = link_to root_path do 
       = image_tag asset_path("material/logo/logo-white.png")

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,12 +1,12 @@
+= render 'layouts/sighIn_up_logout-flash'
 .usersLogin
   .usersLoginHeader
-    = link_to '#' do 
+    = link_to root_path do 
       = image_tag asset_path("material/logo/logo.png")
   .layout
     .layout__left
     .layout__center 
       = form_with scope: resource, as: resource_name, url: session_path(resource_name), local: true do |f|
-        = devise_error_messages!
         .login__no__account
           %p アカウントをお持ちでない方はこちら
           = link_to new_user_registration_path, class: "sign__up__btn" do

--- a/app/views/layouts/_sighIn_up_logout-flash.html.haml
+++ b/app/views/layouts/_sighIn_up_logout-flash.html.haml
@@ -1,0 +1,3 @@
+.sighIn_up_logout-flash
+  - flash.each do |key, value|
+    = content_tag :div, value, class: key

--- a/app/views/products/shared/_header.html.haml
+++ b/app/views/products/shared/_header.html.haml
@@ -1,8 +1,9 @@
+= render 'layouts/sighIn_up_logout-flash'
 .header
   .headerBox 
     .topBox
       %h1.rightIcon
-        = link_to image_tag(asset_path("material/logo/logo.png"),class: "rightIcon__furima"),"#"
+        = link_to image_tag(asset_path("material/logo/logo.png"),class: "rightIcon__furima"),root_path
       .searchBox
         %form.mainForm
           .mainForm__inputBox

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,6 @@
-require_relative 'boot'
+require_relative "boot"
 
-require 'rails/all'
+require "rails/all"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -10,7 +10,7 @@ module Bmarket
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-
+    config.i18n.default_locale = :ja
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/device.ja.yml
+++ b/config/locales/device.ja.yml
@@ -1,0 +1,142 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザ
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントは凍結されています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: アカウント登録もしくはログインしてください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: あなたのメール変更（%{email}）のお知らせいたします。
+        subject: メール変更完了。
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されたことを通知します。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントの凍結解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか?
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか?
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントが凍結されているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか?
+        didn_t_receive_unlock_instructions: アカウントの凍結解除方法のメールを受け取っていませんか?
+        forgot_your_password: パスワードを忘れましたか?
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントの凍結解除方法を再送する
+      send_instructions: アカウントの凍結解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントを凍結解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: は凍結されていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,222 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: "バリデーションに失敗しました: %{errors}"
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+      - 日
+      - 月
+      - 火
+      - 水
+      - 木
+      - 金
+      - 土
+    abbr_month_names:
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+    day_names:
+      - 日曜日
+      - 月曜日
+      - 火曜日
+      - 水曜日
+      - 木曜日
+      - 金曜日
+      - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+    order:
+      - :year
+      - :month
+      - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: を入力してください
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: "バリデーションに失敗しました: %{errors}"
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ""
+      format:
+        delimiter: ""
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ""
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ""
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後
+
+  ja:
+  activerecord:
+    attributes:
+      user: 
+        name: 名前
+        family_name: 名字
+        first_name: 名前
+        family_name_kana: 名字（カナ）
+        first_name_kana: 名前（カナ）
+        nickname: ニックネーム
+        password: パスワード
+        password_confirmation: パスワード確認
+        email: メールアドレス
+        birthday: 生年月日


### PR DESCRIPTION
#what
　ユーザー新規登録の設定
　ユーザー新規登録時のバリデーションの設定
　新規登録・ログイン失敗時のエラーメッセージの表示
　ログイン・ログアウト時のflashメッセージの表示
　英語を日本語表記に変更
　ログイン時以外の画面遷移先変更
　単体テスト未実装
#why
　不正なデータが入らないように、バリデーションをかける必要があるため。

・新規登録時のバリデーション
https://i.gyazo.com/5773556780935c881868f5b2054f14b0.mp4

・ログイン失敗時のエラーメッセージの表示
https://i.gyazo.com/0f1190372651155b8bffb8111d52f7be.mp4

・サインアップ後、ログイン時の画面表示
![image](https://user-images.githubusercontent.com/61643968/82134406-90011c00-9832-11ea-9171-f963af4fb3f1.png)

![image](https://user-images.githubusercontent.com/61643968/82134427-d9ea0200-9832-11ea-9910-d959bae55734.png)


・ログアウト時の画面表示
![image](https://user-images.githubusercontent.com/61643968/82134451-043bbf80-9833-11ea-83bd-6d135cecd974.png)

