### PR TITLE
Add addresses list

### DIFF
--- a/app/assets/stylesheets/_addressesIndex.scss
+++ b/app/assets/stylesheets/_addressesIndex.scss
@@ -1,0 +1,89 @@
+.addressMain {
+  display: flex;
+  background-color: #f8f8f8;
+  padding-top: 40px;
+  
+  .addressSide {
+    padding-left: 180px;
+  }
+  
+  .addressesIndex {
+    margin: 0 auto;
+    width: 700px;
+    height: 440px;
+    background-color: white;
+    align-items: center;
+    
+    .menu {
+      height: 110px;
+      text-align: center;
+      border-bottom: 1px solid;
+      border-color: rgba($color: #ebe7e7be, $alpha: 1.0);
+      h1 {
+        font-size: 30px;
+        font-weight: bold;
+        line-height: 110px;
+      }
+    }
+    
+    .index {
+      height: 80px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      border-bottom: 1px solid;
+      border-color: rgba($color: #ebe7e7be, $alpha: 1.0);
+      h2 {
+        font-size: 20px;
+      }
+    }
+    
+    .address {
+      height: 250px;
+      
+      &__box {
+        width: 100%;
+        padding-left: 140px;
+        display: flex;
+        border-bottom: 3px solid;
+        border-color: #ebe7e7be;
+        padding: 10px 0 10px 140;
+        &__show{
+          width: 68%;
+          p{
+            font-weight: bold;
+          }
+        }
+        &__delete {
+          width: 38%;
+          display: flex;
+          justify-content: center;
+          align-items: center;
+        }
+        &__btn {
+          height: 40px;
+          width: 65px;
+          border-radius: 3px;
+          color: white;
+          background-color: rgb(240, 51, 51);
+          font-size: large;
+        }
+      }
+      &__add{
+        width: 300px;
+        height: 45px;
+        line-height: 45px;
+        text-align: center;
+        background-color: #3CCACE;
+        margin: 40px auto;
+        border-radius: 3px;
+        cursor: pointer;
+        a{
+        color: white;
+        }
+      }
+    }
+    
+  }
+}
+

--- a/app/assets/stylesheets/_addressesIndex.scss
+++ b/app/assets/stylesheets/_addressesIndex.scss
@@ -69,6 +69,9 @@
           font-size: large;
         }
       }
+      a{
+        color: white;
+      }
       &__add{
         width: 300px;
         height: 45px;
@@ -78,9 +81,6 @@
         margin: 40px auto;
         border-radius: 3px;
         cursor: pointer;
-        a{
-        color: white;
-        }
       }
     }
     

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,7 @@
 @import "sessions";
 @import "purchase";
 @import "addresses";
+@import "addressesIndex";
 @import "sighIn_up_logout-flash";
 @import "credits";
 @import "purchaseShow";

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,11 +1,11 @@
 class AddressesController < ApplicationController
   def index
     addresses = Address.where(user_id: current_user.id)
-    if addresses.blank?
-      redirect_to new_address_path
-    else
+    # if addresses.blank?
+    #   redirect_to new_address_path
+    # else
       @addresses = Address.where(user_id: current_user.id)
-    end
+    # end
   end
   
   def new

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,11 +1,6 @@
 class AddressesController < ApplicationController
   def index
-    addresses = Address.where(user_id: current_user.id)
-    # if addresses.blank?
-    #   redirect_to new_address_path
-    # else
-      @addresses = Address.where(user_id: current_user.id)
-    # end
+    @addresses = Address.where(user_id: current_user.id)
   end
   
   def new

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,19 +1,41 @@
 class AddressesController < ApplicationController
-
+  def index
+    addresses = Address.where(user_id: current_user.id)
+    if addresses.blank?
+      redirect_to new_address_path
+    else
+      @addresses = Address.where(user_id: current_user.id)
+    end
+  end
+  
   def new
     @address = Address.new
   end
-
+  
   def create
     @address = Address.new(address_params)
     if @address.save
-      redirect_to user_path(current_user.id), notice: '登録完了しました。'
+      redirect_to addresses_path, notice: '登録完了しました。'
     else
       flash.now[:alert] = '未入力項目があります。'
       render :new
     end
   end
-
+  
+  def destroy 
+    address = Address.find_by(id:params[:id])
+    if address.present? && address.user_id == current_user.id
+      if Purchase.find_by(address_id:address.id) == nil
+        address.delete
+        redirect_to addresses_path, notice: "削除が完了しました。"
+      else
+        redirect_to addresses_path, notice: "取引に使われている為、削除できません。"
+      end
+    else
+      redirect_to root_path
+    end
+  end
+  
   private
   def address_params
     params.require(:address).permit(:family_name, :first_name, :family_name_kana, :first_name_kana, :zipcode, :prefecture, :city, :town, :town_number, :building, :tel,).merge(user_id: current_user.id)

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -29,7 +29,7 @@ class PurchasesController < ApplicationController
 
     #bmarket DB保存
     @purchase = Purchase.new(create_purchase)
-    if @purchase.save && @product.update(status:"売却済")
+    if @purchase.save && @product.update(status:"売却済") && @product.user_id != current_user.id
       redirect_to product_purchase_path(@product,@purchase)
     else
       render "new"

--- a/app/views/addresses/_address.html.haml
+++ b/app/views/addresses/_address.html.haml
@@ -1,0 +1,13 @@
+.address__box
+  .address__box__show
+    %p 郵便番号
+    = address.zipcode
+    %p 住所
+    = "#{Prefecture.find(address.prefecture).name}#{address.city}#{address.town}#{address.town_number}#{address.building}"
+    %br/
+    %p 氏名
+    = "#{address.family_name} #{address.first_name}"
+  .address__box__delete
+    = form_tag(address_path(address.id), method: :delete) do
+      %input{ type: "hidden"}
+      %button.address__box__btn 削除

--- a/app/views/addresses/index.html.haml
+++ b/app/views/addresses/index.html.haml
@@ -10,7 +10,7 @@
       %h2 お届け先住所一覧
     .address
       = render @addresses
-      .address__add
-        = link_to new_address_path do
+      = link_to new_address_path do
+        .address__add
           住所新規登録
 

--- a/app/views/addresses/index.html.haml
+++ b/app/views/addresses/index.html.haml
@@ -1,0 +1,16 @@
+.addressHeader 
+  = render "products/shared/header"
+.addressMain
+  .addressSide
+    = render "users/user_menu_bar"
+  .addressesIndex
+    .menu
+      %h1 お届け先住所登録
+    .index
+      %h2 お届け先住所一覧
+    .address
+      = render @addresses
+      .address__add
+        = link_to new_address_path do
+          住所新規登録
+

--- a/app/views/users/_user_menu_bar.html.haml
+++ b/app/views/users/_user_menu_bar.html.haml
@@ -41,9 +41,9 @@
     %li.mypageNav__list__item
       = link_to "プロフィール","#",class:"item__link"
     %li.mypageNav__list__item
-      = link_to "お届け先住所変更",new_address_path,class:"item__link"
+      = link_to "お届け先住所登録",addresses_path,class:"item__link"
     %li.mypageNav__list__item
-      = link_to "支払い方法",credit_path,class:"item__link"
+      = link_to "支払い方法",credit_path(current_user),class:"item__link"
     %li.mypageNav__list__item
       = link_to "メール/パスワード","#",class:"item__link"
     %li.mypageNav__list__item


### PR DESCRIPTION
# What
住所一覧機能及び、住所削除機能を追加しました。

# Why
住所を複数登録する際の挙動を改善する為。

## Details
・マイページのメニューから住所新規登録に遷移する際の挙動を変更しました。
　住所が既にある状態なら一覧画面に遷移します。
・住所削除機能を追加しました。
　外部キーの都合上、住所が一度でも取引に使われていると削除できません。
　改善の余地大アリですが、購入関連のDB設計にも影響するのでそのままにしてます。
　削除できない場合でもアラート表示で住所一覧に戻るようにしています。
・マイページのメニュー、クレジットカード登録画面に遷移するパスに引数として
　current_user渡すようにしました。（無いと住所一覧表示でエラーでます）
