### PR TITLE
Develop zipcode search

### DIFF
--- a/app/assets/javascripts/addresses.js
+++ b/app/assets/javascripts/addresses.js
@@ -16,7 +16,7 @@ $(function(){
       return forAddress
     }
   }
-  $("#address_zipcode").on("keyup",function(e){
+  $(document).on("keyup","#address_zipcode",function(e){
     zipcode = $("#address_zipcode").val()
     if (zipcode.length == 7){
       url = "https://zipcloud.ibsnet.co.jp/api/search?callback=?"
@@ -28,8 +28,8 @@ $(function(){
           if (addresses.results == null ){
             alert("入力された郵便番号は存在しません。")
           } else {
+            $("#address_prefecture").val(addresses.results[0].prefcode)
             if (addresses.results.length == 1) {
-              $("#address_prefecture").val(addresses.results[0].prefcode)
               $("#address_city").val(addresses.results[0].address2)
               $("#address_town").val(addresses.results[0].address3)
             } else {

--- a/app/assets/javascripts/addresses.js
+++ b/app/assets/javascripts/addresses.js
@@ -1,0 +1,57 @@
+$(function(){
+  function compareAddress(fromAddress,forAddress){
+    // fromが比較元、forが比較先
+    // 住所を比較して、前から重複する部分のみ取り出す
+    let result = ""
+    if ( fromAddress != forAddress ){
+      for(let i = 0;i < forAddress.length; i++){
+        if (fromAddress.charAt(i) == forAddress.charAt(i)){
+          result += forAddress.charAt(i)
+        } else {
+          break;
+        }
+      }
+      return result
+    } else {
+      return forAddress
+    }
+  }
+  $("#address_zipcode").on("keyup",function(e){
+    zipcode = $("#address_zipcode").val()
+    if (zipcode.length == 7){
+      url = "https://zipcloud.ibsnet.co.jp/api/search?callback=?"
+      $.getJSON( url, {
+        zipcode: zipcode
+      })
+      .done(function(addresses) {
+        if (addresses.status == "200") {
+          if (addresses.results == null ){
+            alert("入力された郵便番号は存在しません。")
+          } else {
+            if (addresses.results.length == 1) {
+              $("#address_prefecture").val(addresses.results[0].prefcode)
+              $("#address_city").val(addresses.results[0].address2)
+              $("#address_town").val(addresses.results[0].address3)
+            } else {
+              addresses.results.forEach(function(address,i){
+                if (i == 0) {
+                  compAddress2 = address.address2
+                  compAddress3 = address.address3
+                } else {
+                  compAddress = compareAddress(address.address2,compAddress2)
+                  compAddress2 = compAddress
+                  compAddress = compareAddress(address.address3,compAddress3)
+                  compAddress3 = compAddress
+                }
+              })
+              $("#address_city").val(compAddress2)
+              $("#address_town").val(compAddress3)
+            }
+          }
+        } else {
+          alert(addresses.message)
+        }
+      })
+    }
+  })
+})


### PR DESCRIPTION
# What
住所登録における、郵便番号検索の実装

# Why
住所入力間違いを防ぐ為

## Detail
・昨今これが出来ないのはないわ、ということで実装してみました。
・JavaScriptで実装してみました。zipcloud(http://zipcloud.ibsnet.co.jp/doc/api)のapi使用してます。
・複数住所が登録されている郵便番号を入力した場合（例：4520961等）、全住所で共通している部分のみ反映させてます。