### PR TITLE
Develop breadcrumb list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,3 +87,4 @@ gem 'carrierwave'
 gem 'mini_magick'
 gem 'rails-i18n'
 gem 'fog-aws'
+gem "gretel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,8 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -367,6 +369,7 @@ DEPENDENCIES
   factory_bot_rails
   fog-aws
   font-awesome-rails
+  gretel
   haml-rails (~> 2.0)
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/_breadcrumbs.scss
+++ b/app/assets/stylesheets/_breadcrumbs.scss
@@ -1,0 +1,13 @@
+.breadcrumbs {
+  font-size: 13px;
+  width: 100%;
+  min-height: 82px;
+  margin: 0 auto;
+  padding: 0 23px;
+  a{
+    color: #333;
+  }
+  a:hover{
+    color: #3CCACE;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 @import "reset";
 @import "font-awesome";
 @import "floatIcon";
+@import "breadcrumbs";
 @import "productsTop";
 @import "usersShow";
 @import "creditsNew";

--- a/app/views/addresses/index.html.haml
+++ b/app/views/addresses/index.html.haml
@@ -1,4 +1,5 @@
 .addressHeader 
+  - breadcrumb :address
   = render "products/shared/header"
 .addressMain
   .addressSide

--- a/app/views/credits/show.html.haml
+++ b/app/views/credits/show.html.haml
@@ -1,4 +1,5 @@
-.creditHeader 
+.creditHeader
+  - breadcrumb :credit
   = render "products/shared/header"
 .creditMain
   .creditSide

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -1,4 +1,4 @@
-- breadcrumbs :productsedit
+- breadcrumb :productsedit
 = render "products/shared/header"
 .productsNew
   .productsNew__container

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -1,4 +1,5 @@
-= render "products/shared/header";
+- breadcrumbs :productsedit
+= render "products/shared/header"
 .productsNew
   .productsNew__container
     = form_with(model:@product,local:true,class:"container__newForm") do |f|

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -1,3 +1,7 @@
+- if request.referer&.include?(user_path(current_user))
+  - breadcrumb :productsnew_from_user
+- else
+  - breadcrumb :productsnew_from_top
 = render "products/shared/header";
 .productsNew
   .productsNew__container

--- a/app/views/products/shared/_breadcrumbs.html.haml
+++ b/app/views/products/shared/_breadcrumbs.html.haml
@@ -1,0 +1,2 @@
+.breadcrumbs
+  = breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs-list"

--- a/app/views/products/shared/_breadcrumbs.html.haml
+++ b/app/views/products/shared/_breadcrumbs.html.haml
@@ -1,2 +1,2 @@
 .breadcrumbs
-  = breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs-list"
+  = breadcrumbs pretext: "",separator: " ＞ ", class: "breadcrumbs-list"

--- a/app/views/products/shared/_header.html.haml
+++ b/app/views/products/shared/_header.html.haml
@@ -28,4 +28,4 @@
       - else
         = link_to user_path(current_user), class:"boxUnder__right__mypage" do
           マイページ
-= render "products/shared/breadcrumbs"
+  = render "products/shared/breadcrumbs"

--- a/app/views/products/shared/_header.html.haml
+++ b/app/views/products/shared/_header.html.haml
@@ -28,3 +28,4 @@
       - else
         = link_to user_path(current_user), class:"boxUnder__right__mypage" do
           マイページ
+= render "products/shared/breadcrumbs"

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :product
 = render "products/shared/header";
 .productDtail
   .productShowContent

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,4 +1,5 @@
 .userShowHeader
+  - breadcrumb :mypage
   = render "products/shared/header"
 %main.contents.clearfix
 

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,34 @@
+crumb :root do
+  link "トップページ", root_path
+end
+crumb :mypage do
+  link "マイページ", user_path(current_user)
+end
+crumb :address do
+  link "お届け先住所登録", addresses_path
+  parent :mypage
+end
+crumb :addressesnew do
+  link "お届け先住所新規登録", new_address_path
+  parent :mypage
+end
+crumb :credit do
+  link "支払い方法", credit_path(params[:id])
+  parent :mypage
+end
+crumb :product do
+  link "商品詳細ページ", product_path(params[:id])
+  parent :root
+end
+crumb :productsnew_from_user do
+  link "商品出品ページ", new_product_path
+  parent :mypage
+end
+crumb :productsnew_from_top do
+  link "商品出品ページ", new_product_path
+  parent :root
+end
+crumb :productsedit do
+  link "商品情報編集ページ", edit_product_path(params[:id])
+  parent :product
+end


### PR DESCRIPTION
# What
パンくず機能の実装

# Why
ユーザーの画面遷移を容易にする為

## Details
・views/products/shared/headerに埋め込む形で実装してます。
・現在ヘッダを表示させているページには全て対応させています。
・出品画面に関しては、遷移元がトップかマイページかでパンくず表示変えてます。

## Screenshot
https://gyazo.com/191b4c378699986c507bb25586f164de
https://gyazo.com/654250b5c940eb837f224234f4d57a57
https://gyazo.com/63877f3c4eb776bd04ced0bd44e2876e
https://gyazo.com/16738e0fe9900eaca8f8be2d0762010b