### PR TITLE
Add return nil

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -16,6 +16,7 @@ class PurchasesController < ApplicationController
   end
 
   def create
+    return nil if @product.user_id == current_user.id || Purchase.find_by(product_id:@product.id) != nil
     Payjp.api_key = Rails.application.credentials.dig(:payjp, :PAYJP_SECRET_KEY)
     token = Payjp::Charge.create(
       amount: @product.price,

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -136,7 +136,6 @@
             購入する
       -else
     -else not user_signed_in?
-
     .commentBox
       %ul
       .commentBox__box


### PR DESCRIPTION
# What
出品者と購入者が同じ、または
購入済みの商品である場合、
createアクションを動かせないようにする。

# Why
悪意あるユーザーからの攻撃を防ぐ為。

## レビュー者へ
product#showかなんかのビューにpurchase#createへ直で飛ぶlink_toを
追加するなりして頂けると検証できるかと。
ちょっと怖いんでお願いします