### PR TITLE
エラーハンドリングの追加

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -31,6 +31,7 @@ class ProductsController < ApplicationController
   end
   
   def show
+    redirect_to root_path unless move_to_root_end_of_products.nil?
     if user_signed_in?
       @addresses = Address.where(user_id:current_user.id)
       @credit = Credit.where(user_id:current_user.id)
@@ -89,5 +90,9 @@ class ProductsController < ApplicationController
     @product = Product.find(params[:id])
   end
   
+  def move_to_root_end_of_products
+    @productEndes = Purchase.find_by(product_id:@product.id)
+  
+  end
 end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -32,7 +32,6 @@ class ProductsController < ApplicationController
   end
   
   def show
-    redirect_to root_path unless move_to_root_end_of_products.nil?
     @productEndes = Purchase.find_by(product_id:@product.id)
     if user_signed_in?
       @addresses = Address.where(user_id:current_user.id)

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,7 @@
 class ProductsController < ApplicationController
   before_action :move_to_root, except: [:index, :show]
   before_action :set_product, only: [:show, :edit, :destroy, :update]
+  before_action :move_to_root_end_of_products, only: [:show, :update]
 
   def index
     @categoryProducts = Product.includes(:images).where(status: 0).limit(3).order("id DESC")
@@ -32,6 +33,7 @@ class ProductsController < ApplicationController
   
   def show
     redirect_to root_path unless move_to_root_end_of_products.nil?
+    @productEndes = Purchase.find_by(product_id:@product.id)
     if user_signed_in?
       @addresses = Address.where(user_id:current_user.id)
       @credit = Credit.where(user_id:current_user.id)
@@ -48,6 +50,9 @@ class ProductsController < ApplicationController
   end
 
   def update
+    if  current_user.id == @product.user_id
+      return nil 
+    end
     brand = Brand.find_by(brand_params)
     if brand == nil
       @brand = Brand.create(brand_params)
@@ -92,7 +97,6 @@ class ProductsController < ApplicationController
   
   def move_to_root_end_of_products
     @productEndes = Purchase.find_by(product_id:@product.id)
-  
   end
 end
 

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -10,6 +10,7 @@ class PurchasesController < ApplicationController
   end
 
   def new
+    redirect_to root_path unless not current_user.id == @product.user_id
     redirect_to root_path unless move_to_root_end_of_products.nil?
     Payjp.api_key = Rails.application.credentials.dig(:payjp, :PAYJP_SECRET_KEY)
     @purchase = Purchase.new

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -10,6 +10,7 @@ class PurchasesController < ApplicationController
   end
 
   def new
+    redirect_to root_path unless move_to_root_end_of_products.nil?
     Payjp.api_key = Rails.application.credentials.dig(:payjp, :PAYJP_SECRET_KEY)
     @purchase = Purchase.new
     @addresses = current_user.addresses
@@ -52,4 +53,10 @@ class PurchasesController < ApplicationController
   def set_credit
     @credit = @customer.cards.retrieve(current_user.credit.card_id)
   end
+
+  def move_to_root_end_of_products
+    @productEndes = Purchase.find_by(product_id:@product.id)
+  end
+
+
 end

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -115,26 +115,29 @@
             =link_to "#" do
               %i.fa.fa-flag
               不適切な商品の通報
-    -if user_signed_in? && current_user.id == @product.user_id
-    -elsif user_signed_in?
-      -if @addresses.present? && @credit.present?
-        = link_to new_product_purchase_path(@product) do
-          .productPurchase
-            購入する
-      - elsif @addresses.blank? && @credit.blank?
-        = link_to user_path(current_user) ,data: { confirm: "住所の登録をお願いします。\nクレジットカードの登録をお願いします。"} do
-          .productPurchase
-            購入する
-      -elsif @addresses.blank?
-        = link_to new_address_path(current_user),data: { confirm: "住所の登録をお願いします。"} do
-          .productPurchase
-            購入する
-      -elsif @credit.blank?
-        = link_to new_credit_path(current_user) ,data: { confirm: "クレジットカードの登録をお願いします。"} do
-          .productPurchase
-            購入する
-      -else
-    -else not user_signed_in?
+    -if @product.status ==0
+      -if user_signed_in? && current_user.id == @product.user_id
+      -elsif user_signed_in?
+        -if @addresses.present? && @credit.present?
+          = link_to new_product_purchase_path(@product) do
+            .productPurchase
+              購入する
+        - elsif @addresses.blank? && @credit.blank?
+          = link_to user_path(current_user) ,data: { confirm: "住所の登録をお願いします。\nクレジットカードの登録をお願いします。"} do
+            .productPurchase
+              購入する
+        -elsif @addresses.blank?
+          = link_to new_address_path(current_user),data: { confirm: "住所の登録をお願いします。"} do
+            .productPurchase
+              購入する
+        -elsif @credit.blank?
+          = link_to new_credit_path(current_user) ,data: { confirm: "クレジットカードの登録をお願いします。"} do
+            .productPurchase
+              購入する
+        -else
+      -else not user_signed_in?
+    -else
+    
 
     .commentBox
       %ul

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -115,27 +115,28 @@
             =link_to "#" do
               %i.fa.fa-flag
               不適切な商品の通報
-    -if user_signed_in? && current_user.id == @product.user_id
-    -elsif user_signed_in?
-      -if @addresses.present? && @credit.present?
-        = link_to new_product_purchase_path(@product) do
-          .productPurchase
-            購入する
-      - elsif @addresses.blank? && @credit.blank?
-        = link_to user_path(current_user) ,data: { confirm: "住所の登録をお願いします。\nクレジットカードの登録をお願いします。"} do
-          .productPurchase
-            購入する
-      -elsif @addresses.blank?
-        = link_to new_address_path(current_user),data: { confirm: "住所の登録をお願いします。"} do
-          .productPurchase
-            購入する
-      -elsif @credit.blank?
-        = link_to new_credit_path(current_user) ,data: { confirm: "クレジットカードの登録をお願いします。"} do
-          .productPurchase
-            購入する
-      -else
-    -else not user_signed_in?
-    
+    -if @productEndes.nil?
+      -if user_signed_in? && current_user.id == @product.user_id
+      -elsif user_signed_in?
+        -if @addresses.present? && @credit.present?
+          = link_to new_product_purchase_path(@product) do
+            .productPurchase
+              購入する
+        - elsif @addresses.blank? && @credit.blank?
+          = link_to user_path(current_user) ,data: { confirm: "住所の登録をお願いします。\nクレジットカードの登録をお願いします。"} do
+            .productPurchase
+              購入する
+        -elsif @addresses.blank?
+          = link_to new_address_path(current_user),data: { confirm: "住所の登録をお願いします。"} do
+            .productPurchase
+              購入する
+        -elsif @credit.blank?
+          = link_to new_credit_path(current_user) ,data: { confirm: "クレジットカードの登録をお願いします。"} do
+            .productPurchase
+              購入する
+        -else
+      -else not user_signed_in?
+    -else
 
     .commentBox
       %ul

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -115,28 +115,26 @@
             =link_to "#" do
               %i.fa.fa-flag
               不適切な商品の通報
-    -if @product.status ==0
-      -if user_signed_in? && current_user.id == @product.user_id
-      -elsif user_signed_in?
-        -if @addresses.present? && @credit.present?
-          = link_to new_product_purchase_path(@product) do
-            .productPurchase
-              購入する
-        - elsif @addresses.blank? && @credit.blank?
-          = link_to user_path(current_user) ,data: { confirm: "住所の登録をお願いします。\nクレジットカードの登録をお願いします。"} do
-            .productPurchase
-              購入する
-        -elsif @addresses.blank?
-          = link_to new_address_path(current_user),data: { confirm: "住所の登録をお願いします。"} do
-            .productPurchase
-              購入する
-        -elsif @credit.blank?
-          = link_to new_credit_path(current_user) ,data: { confirm: "クレジットカードの登録をお願いします。"} do
-            .productPurchase
-              購入する
-        -else
-      -else not user_signed_in?
-    -else
+    -if user_signed_in? && current_user.id == @product.user_id
+    -elsif user_signed_in?
+      -if @addresses.present? && @credit.present?
+        = link_to new_product_purchase_path(@product) do
+          .productPurchase
+            購入する
+      - elsif @addresses.blank? && @credit.blank?
+        = link_to user_path(current_user) ,data: { confirm: "住所の登録をお願いします。\nクレジットカードの登録をお願いします。"} do
+          .productPurchase
+            購入する
+      -elsif @addresses.blank?
+        = link_to new_address_path(current_user),data: { confirm: "住所の登録をお願いします。"} do
+          .productPurchase
+            購入する
+      -elsif @credit.blank?
+        = link_to new_credit_path(current_user) ,data: { confirm: "クレジットカードの登録をお願いします。"} do
+          .productPurchase
+            購入する
+      -else
+    -else not user_signed_in?
     
 
     .commentBox


### PR DESCRIPTION
#What
3. 自身が出品した商品の購入画面へURLを直打ちしても飛べないようになっている
5. 一度購入された商品は「購入画面へ進む」ボタンを押せなくなっている
6. 一度購入された商品の購入画面へURLを直打ちしても飛べなくなっている
9. 他人の商品の編集画面へURLを直打ちしても飛べないようになっている

https://trello.com/b/CtVsdowb/74%E6%9C%9Fteamb%E6%9C%80%E7%B5%82%E8%AA%B2%E9%A1%8C%E3%83%90%E3%83%83%E3%82%AF%E3%83%AD%E3%82%B0

#Why
サイトのエラーハンドリングの精度の向上のため
