### PR TITLE
マイページから出品中と売却済の商品一覧

### DIFF
--- a/app/assets/javascripts/infomations.coffee
+++ b/app/assets/javascripts/infomations.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/infomations.coffee
+++ b/app/assets/javascripts/infomations.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,3 +14,4 @@
 @import "sighIn_up_logout-flash";
 @import "credits";
 @import "purchaseShow";
+@import "infomations";

--- a/app/assets/stylesheets/infomations.scss
+++ b/app/assets/stylesheets/infomations.scss
@@ -1,0 +1,39 @@
+.infomationMain {
+  display: flex;
+  background-color: #f8f8f8;
+  padding-top: 40px;
+  
+  .infomationSide {
+    padding-left: 180px;
+  }
+  
+  .infomationIndex {
+    height: 100%;
+    margin: 0 auto;
+    width: 700px;
+    background-color: white;
+    align-items: center;
+    
+    .index {
+      height: 80px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      border-bottom: 1px solid;
+      border-color: rgba($color: #ebe7e7be, $alpha: 1.0);
+      h2 {
+        font-size: 20px;
+      }
+    }
+    
+    .infomation {
+      .listBtn {
+        margin: 6px;
+      }
+      .productBody {
+        color: black;
+      }
+    }
+  }
+}
+

--- a/app/controllers/infomations_controller.rb
+++ b/app/controllers/infomations_controller.rb
@@ -1,5 +1,6 @@
 class InfomationsController < ApplicationController
-  before_action :redirect_root
+  before_action :redirect_root,only:[:index,:show]
+
 
   def index
     @products = Product.includes(:images).where(user_id: current_user.id).where(status: 0).order("id DESC")
@@ -12,7 +13,7 @@ class InfomationsController < ApplicationController
   private
 
   def redirect_root
-    redirect_to root_path unless user_signed_in?
+    redirect_to root_path unless user_signed_in? && current_user.present?
   end
 
 end

--- a/app/controllers/infomations_controller.rb
+++ b/app/controllers/infomations_controller.rb
@@ -1,6 +1,6 @@
 class InfomationsController < ApplicationController
   before_action :redirect_root,only:[:index,:show]
-
+  before_action :set_products,only:[:index,:show]
 
   def index
     @products = Product.includes(:images).where(user_id: current_user.id).where(status: 0).order("id DESC")
@@ -11,6 +11,9 @@ class InfomationsController < ApplicationController
   end
 
   private
+  def set_products
+    @products = Product.includes(:images).where(user_id: current_user.id).where(status: 0).order("id DESC")
+  end
 
   def redirect_root
     redirect_to root_path unless user_signed_in?

--- a/app/controllers/infomations_controller.rb
+++ b/app/controllers/infomations_controller.rb
@@ -3,11 +3,9 @@ class InfomationsController < ApplicationController
   before_action :set_products,only:[:index,:show]
 
   def index
-    @products = Product.includes(:images).where(user_id: current_user.id).where(status: 0).order("id DESC")
   end
 
   def show
-    @products = Product.includes(:images).where(user_id: current_user.id).where(status: 1).order("id DESC")
   end
 
   private

--- a/app/controllers/infomations_controller.rb
+++ b/app/controllers/infomations_controller.rb
@@ -13,7 +13,7 @@ class InfomationsController < ApplicationController
   private
 
   def redirect_root
-    redirect_to root_path unless user_signed_in? && current_user.present?
+    redirect_to root_path unless user_signed_in?
   end
 
 end

--- a/app/controllers/infomations_controller.rb
+++ b/app/controllers/infomations_controller.rb
@@ -1,0 +1,18 @@
+class InfomationsController < ApplicationController
+  before_action :redirect_root
+
+  def index
+    @products = Product.includes(:images).where(user_id: current_user.id).where(status: 0).order("id DESC")
+  end
+
+  def show
+    @products = Product.includes(:images).where(user_id: current_user.id).where(status: 1).order("id DESC")
+  end
+
+  private
+
+  def redirect_root
+    redirect_to root_path unless user_signed_in?
+  end
+
+end

--- a/app/helpers/infomations_helper.rb
+++ b/app/helpers/infomations_helper.rb
@@ -1,0 +1,2 @@
+module InfomationsHelper
+end

--- a/app/views/infomations/index.html.haml
+++ b/app/views/infomations/index.html.haml
@@ -1,0 +1,23 @@
+.infomationHeader 
+  = render "products/shared/header"
+.infomationMain
+  .infomationSide
+    = render "users/user_menu_bar"
+  .infomationIndex
+    .index
+      %h2 出品中
+    .infomation
+      - @products.each do |product|
+        = link_to product_path(product.id), class: "listBtn" do
+          %figure.listImages
+            = image_tag product.images.first.image_url.url ,alt: "image_url",class: "newImage"
+          .productBody
+            %h3.productBody__name
+              = product.name
+            %ul.productBody__menu
+              %li
+                = "#{product.price}円"
+              %li
+                %i.fa.fa-star.starIcon
+                  0
+            %p.productBody__taxIn（税込）

--- a/app/views/infomations/show.html.haml
+++ b/app/views/infomations/show.html.haml
@@ -1,0 +1,23 @@
+.infomationHeader 
+  = render "products/shared/header"
+.infomationMain
+  .infomationSide
+    = render "users/user_menu_bar"
+  .infomationIndex
+    .index
+      %h2 売却済み
+    .infomation
+      - @products.each do |product|
+        = link_to product_path(product.id), class: "listBtn" do
+          %figure.listImages
+            = image_tag product.images.first.image_url.url ,alt: "image_url",class: "newImage"
+          .productBody
+            %h3.productBody__name
+              = product.name
+            %ul.productBody__menu
+              %li
+                = "#{product.price}円"
+              %li
+                %i.fa.fa-star.starIcon
+                  0
+            %p.productBody__taxIn（税込）

--- a/app/views/users/_user_menu_bar.html.haml
+++ b/app/views/users/_user_menu_bar.html.haml
@@ -13,11 +13,11 @@
     %li.mypageNav__list__item
       = link_to "下書き一覧","#",class:"item__link"
     %li.mypageNav__list__item
-      = link_to "出品した商品 - 出品中","#",class:"item__link"
+      = link_to "出品した商品 - 出品中",  infomations_path,class:"item__link"
     %li.mypageNav__list__item
       = link_to "出品した商品 - 取引中","#",class:"item__link"
     %li.mypageNav__list__item
-      = link_to "出品した商品 - 売却済み","#",class:"item__link"
+      = link_to "出品した商品 - 売却済み",infomation_path(current_user),class:"item__link"
     %li.mypageNav__list__item
       = link_to "購入した商品 - 取引中","#",class:"item__link"
     %li.mypageNav__list__item

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root "products#index"
-  resources :users
+  resources :users 
   resources :credits
   resources :products do
     resources :purchases
@@ -9,4 +9,5 @@ Rails.application.routes.draw do
   resources :brands
   resources :categories
   resources :addresses
+  resources :infomations
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,5 +17,5 @@ Rails.application.routes.draw do
   resources :brands
   resources :categories
   resources :addresses
-  resources :infomations
+  resources :infomations,only:[:index, :show]
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2020_05_26_064634) do
-
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "family_name", null: false
@@ -91,7 +89,7 @@ ActiveRecord::Schema.define(version: 2020_05_26_064634) do
     t.string "from", null: false
     t.string "delivery_day", null: false
     t.bigint "price", null: false
-    t.string "size"
+    t.string "size", null: false
     t.string "status", null: false
     t.bigint "user_id", null: false
     t.bigint "brand_id", null: false

--- a/spec/helpers/infomations_helper_spec.rb
+++ b/spec/helpers/infomations_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the InfomationsHelper. For example:
+#
+# describe InfomationsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe InfomationsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/infomations_request_spec.rb
+++ b/spec/requests/infomations_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Infomations", type: :request do
+
+end


### PR DESCRIPTION
# What
マイページから出品中の商品一覧画面、売却済の商品一覧画面を見れるようにしました。
コントローラーとビューを作成。ログイン中のユーザー以外はトップページに遷移するように実装。

# Why
マイページからログイン中のユーザーの商品の状況を確認しやすくするため。