### PR TITLE
商品詳細ページのコメント機能の実装

### DIFF
--- a/app/assets/javascripts/comments.coffee
+++ b/app/assets/javascripts/comments.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/_productsShow.scss
+++ b/app/assets/stylesheets/_productsShow.scss
@@ -156,56 +156,10 @@
   background: #3ccace;
   font-size: 30px;
   text-align: center;
-  color:#fff;
+  color: #fff;
   border-radius: 100px;
   a {
     line-height: 56px;
-  }
-}
-
-.commentBox {
-  padding: 24px;
-  margin: 10px 0;
-  text-align: center;
-  background-color: #ffffff;
-  &__box {
-    &__form {
-      display: block;
-      width: 100%;
-      max-width: 100%;
-      min-height: 104px;
-      padding: 10px;
-      border: 1px solid #ccc;
-      background: #fff;
-      font-size: 16px;
-      line-height: 1.5;
-      input {
-        width: 100%;
-        min-height: 104px;
-        padding: 10px;
-      }
-    }
-    &__notice {
-      padding: 8px;
-      font-size: 14px;
-      background-color: #f8f8f8;
-      margin: 10px 0;
-      text-align: left;
-    }
-    &__btn {
-      margin-left: 20%;
-      font-size: 18px;
-      line-height: 48px;
-      background: #3ccace;
-      border: 1px solid #3ccace;
-      color: #fff;
-      width: 60%;
-      border-radius: 100px;
-      &__comment {
-        color: white;
-        text-rendering: auto;
-      }
-    }
   }
 }
 
@@ -238,4 +192,88 @@
     font-size: 22px;
     position: relative;
   }
+}
+
+.commentBox {
+  margin: 50px 0;
+  padding: 24px;
+  text-align: center;
+  background-color: #fcf6f6;
+}
+.commentList {
+  display: flex;
+  margin-bottom: 20px;
+  i {
+    font-size: 45px;
+    color: #51e2a6;
+    margin-top: 25px;
+  }
+  &__listContent {
+    width: 100%;
+    margin-left: 20px;
+
+    &__name {
+      text-align: left;
+      font-size: 14px;
+    }
+    &__message {
+      border-radius: 5px;
+      text-align: left;
+      position: relative;
+      padding: 22px;
+      background-color: #51e2a6;
+      border-radius: 10px;
+      word-break: break-all;
+    }
+    &__message::before {
+      content: "";
+      position: absolute;
+      display: block;
+      width: 0;
+      height: 0;
+      border-radius: 50%;
+      transform: rotate(45deg);
+      top: 20px;
+      left: -15px;
+      border-bottom: 20px solid #51e2a6;
+      border-left: 20px solid #51e2a6;
+      border-top: 20px solid transparent;
+      border-right: 20px solid transparent;
+    }
+    &__message::after {
+      content: "";
+      position: absolute;
+      display: block;
+      width: 0;
+      height: 0;
+      border-radius: 50%;
+      transform: rotate(45deg);
+      top: 10px;
+      left: -20px;
+      border-bottom: 20px solid #fcf6f6;
+      border-left: 20px solid #fcf6f6;
+      border-top: 20px solid transparent;
+      border-right: 20px solid transparent;
+    }
+  }
+}
+.textForm {
+  width: 100%;
+  height: 104px;
+}
+.noticeMsg {
+  text-align: left;
+  font-size: 14px;
+  padding: 8px;
+  margin: 10px 0;
+  background-color: #f8f8f8;
+}
+.commentBtn {
+  background: #51e2a6;
+  line-height: 48px;
+  color: #fff;
+  font-size: 18px;
+  border-radius: 100px;
+  width: 60%;
+  border: 1px solid #51e2a6;
 }

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the comments controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,18 @@
+class CommentsController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    @comment = Comment.new(comment_params)
+    if @comment.save
+      redirect_to product_path(@comment.product.id), notice: "コメントが投稿されました"
+    else
+      redirect_to product_path(@comment.product.id), notice: "コメントを入力してください"
+    end
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:text).merge(user_id: current_user.id, product_id: params[:product_id])
+  end
+end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -32,6 +32,8 @@ class ProductsController < ApplicationController
   end
   
   def show
+    @comment = Comment.new
+    @comments = @product.comments.includes(:user)
     @productEndes = Purchase.find_by(product_id:@product.id)
     if user_signed_in?
       @addresses = Address.where(user_id:current_user.id)

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,2 @@
+module CommentsHelper
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,6 +3,4 @@ class Comment < ApplicationRecord
   belongs_to :user
 
   validates :text, presence: true
-  validates :user_id, presence: true
-  validates :product_id, presence: true
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,8 @@
+class Comment < ApplicationRecord
+  belongs_to :product
+  belongs_to :user
+
+  validates :text, presence: true
+  validates :user_id, presence: true
+  validates :product_id, presence: true
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -21,7 +21,7 @@ class Product < ApplicationRecord
   validates :status, presence: true
   validates :images, presence: true
 
-  # has_many :comments, dependent: :destroy
+  has_many :comments, dependent: :destroy
   has_one :purchase, dependent: :destroy
   # has_many :products_tags
   # has_many :tags,  through:  :products_tags

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ApplicationRecord
     end
   end
 
-  # has_many :comments
+  has_many :comments
   has_one :credit
   has_many :purchases
   has_many :addresses

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -138,21 +138,30 @@
         -else
       -else not user_signed_in?
     -else
-    
+
     .commentBox
-      %ul
-      .commentBox__box
-        .commentBox__box__form
-          = form_with url: products_path do |f|
-            = f.text_field :product, class: "commentBox__box__form__text"
-        .commentBox__box__notice
-          相手のことを考え丁寧なコメントを心がけましょう。
+      コメント一覧
+      - if @comments
+        - @comments.each do |comment|
+          .commentList
+            .commentList__listIcon
+              %i.fa.fa-user
+            .commentList__listContent
+              .commentList__listContent__name
+                = comment.user.nickname
+              .commentList__listContent__message
+                = comment.text
+              .commentList__listContent__date
+                = comment.updated_at.strftime("%Y-%m-%d %H:%M")
+      - if user_signed_in?
+        = form_with model:[@product, @comment], local: true do |f|
+          = f.text_area :text, placeholder: "コメントする", rows: "2",class: "textForm"
+          .noticeMsg
+            %p
+              相手のことを考え丁寧なコメントを心がけましょう。
+              %br 不快な言葉遣いなどは利用制限や退会処分となることがあります。
           %br
-            不快な言葉遣いなどは利用制限や退会処分となる事があります。
-        =link_to "#" do
-          .commentBox__box__btn
-            %i.fa.fa-comment
-              コメントする
+          = f.submit "コメントする", class: "commentBtn"
     .productFrontAndBackLinks
       %li
         =link_to "#" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   resources :credits
   resources :products do
     resources :purchases
+    resources :comments, only: [:create]
   end
   resources :brands
   resources :categories

--- a/db/migrate/20200526064634_create_comments.rb
+++ b/db/migrate/20200526064634_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :comments do |t|
+      t.text :text, null: false
+      t.references :user, null: false, foreign_key: true
+      t.references :product, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_19_061117) do
+ActiveRecord::Schema.define(version: 2020_05_26_064634) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "family_name", null: false
@@ -42,6 +42,16 @@ ActiveRecord::Schema.define(version: 2020_05_19_061117) do
     t.datetime "updated_at", null: false
     t.string "ancestry"
     t.index ["ancestry"], name: "index_categories_on_ancestry"
+  end
+
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.text "text", null: false
+    t.bigint "user_id", null: false
+    t.bigint "product_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_comments_on_product_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "credits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -113,6 +123,8 @@ ActiveRecord::Schema.define(version: 2020_05_19_061117) do
   end
 
   add_foreign_key "addresses", "users"
+  add_foreign_key "comments", "products"
+  add_foreign_key "comments", "users"
   add_foreign_key "credits", "users"
   add_foreign_key "images", "products"
   add_foreign_key "products", "brands"

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :comment do
+    
+  end
+end

--- a/spec/helpers/comments_helper_spec.rb
+++ b/spec/helpers/comments_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the CommentsHelper. For example:
+#
+# describe CommentsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe CommentsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/comments_request_spec.rb
+++ b/spec/requests/comments_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Comments", type: :request do
+
+end


### PR DESCRIPTION
# what
 商品詳細ページのコメント機能の実装
 ログイン中のみコメントが出来る。（出品者及び購入者）
 ログアウト中は一覧表示のみ見れる。

# whay?
　商品の詳細について、出品者、購入者のやり取りが出来るようにするため
　ログイン中にコメントの投稿
　https://i.gyazo.com/870b10cffc24099593f243874bc8ae7b.mp4

　ログアウト中の一覧表示
　
![image](https://user-images.githubusercontent.com/61643968/82928200-df76e300-9fbc-11ea-9bff-c7389d1edeb6.png)
