### PR TITLE
Fix favorite bug

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -33,6 +33,8 @@ class PurchasesController < ApplicationController
     #bmarket DB保存
     @purchase = Purchase.new(create_purchase)
     if @purchase.save && @product.update(status:"売却済") && @product.user_id != current_user.id
+      favorites = Favorite.where(product_id:@purchase.product_id)
+      favorites.destroy
       redirect_to product_purchase_path(@product,@purchase)
     else
       render "new"

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -33,8 +33,7 @@ class PurchasesController < ApplicationController
     #bmarket DB保存
     @purchase = Purchase.new(create_purchase)
     if @purchase.save && @product.update(status:"売却済") && @product.user_id != current_user.id
-      favorites = Favorite.where(product_id:@purchase.product_id)
-      favorites.destroy
+      Product.find(@product.id).favorites.delete_all
       redirect_to product_purchase_path(@product,@purchase)
     else
       render "new"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -63,6 +63,16 @@ ActiveRecord::Schema.define(version: 2020_05_26_064634) do
     t.index ["user_id"], name: "index_credits_on_user_id"
   end
 
+  create_table "favorites", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "product_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_favorites_on_product_id"
+    t.index ["user_id", "product_id"], name: "index_favorites_on_user_id_and_product_id", unique: true
+    t.index ["user_id"], name: "index_favorites_on_user_id"
+  end
+
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "image_url", null: false
     t.bigint "product_id", null: false
@@ -126,6 +136,8 @@ ActiveRecord::Schema.define(version: 2020_05_26_064634) do
   add_foreign_key "comments", "products"
   add_foreign_key "comments", "users"
   add_foreign_key "credits", "users"
+  add_foreign_key "favorites", "products"
+  add_foreign_key "favorites", "users"
   add_foreign_key "images", "products"
   add_foreign_key "products", "brands"
   add_foreign_key "products", "categories"


### PR DESCRIPTION
# What
購入済み商品のお気に入りを、マイページのお気に入り一覧で表示させなくする

# Why
お気に入り機能の改善の為。

## Details
購入と同時に、購入された商品に関連付けされているfavoritesテーブルのレコードを全削除してます。